### PR TITLE
Corrections de textes de présentation

### DIFF
--- a/lang/fr.php
+++ b/lang/fr.php
@@ -4,7 +4,7 @@ return [
     'welcome' => 'Rechercher dans le catalogue Damco',
     'Search' => 'Rechercher',
     'SearchLabel' => 'Tapez le nom d\'une pièce ou un numéro de produit pour obtenir son prix et sa disponibilité :',
-    'Searching...' => 'Parcours du catalogue Cycle Babac en cours...',
+    'Searching...' => 'Parcours du catalogue de Damco en cours...',
     'NoProductFound' => 'Aucun produit trouvé',
     'Error' => 'Erreur : {{errorMessage}}',
     'Yes' => 'Oui',
@@ -30,6 +30,6 @@ return [
     'searchInput' => [
         'empty' => 'La barre de recherche ne peut pas être vide.',
         'invalid' => 'La recherche contient des caractères invalides.',
-        'placeholder' => 'ex. petites roues ou 12-345-67',
+        'placeholder' => 'ex. bidon ou 48-024-50',
     ],
 ];


### PR DESCRIPTION
Les exemples présentés dans la barre de recherche (`petites roues` et `12-345-67`) de retournent aucun produit. Il pourrait être plus agréable pour l'utilisateur lambda de se faire proposer des exemples retournant des résultats. Par exemple `bidon` ou `48-024-50` offrent chacun une liste de résultats et un seul résultat respectivement.

Également, lorsque le champignon pédale vers les résultats, il est inscrit `Parcours du site Cycle Babac`. Or, le champignon parcourt plutôt le site de Damco.